### PR TITLE
Start recording with adb connect string

### DIFF
--- a/common/stfapi.py
+++ b/common/stfapi.py
@@ -145,7 +145,7 @@ class SmartphoneTestingFarmAPI(object):
 
 
 api = SmartphoneTestingFarmAPI(
-        host=config.get("main", "host"),
-        common_api_path="/api/v1",
-        oauth_token=config.get("main", "oauth_token")
-    )
+    host=config.get("main", "host"),
+    common_api_path="/api/v1",
+    oauth_token=config.get("main", "oauth_token")
+)

--- a/connector.py
+++ b/connector.py
@@ -4,16 +4,10 @@ import json
 import time
 import sys
 import argparse
+
 from stf_connect.client import SmartphoneTestingFarmClient, STFDevicesConnector, STFConnectedDevicesWatcher
 from common import config
 
-HOST = config.get("main", "host")
-OAUTH_TOKEN = config.get("main", "oauth_token")
-DEVICE_SPEC = config.get("main", "device_spec")
-DEVICES_FILE_DIR = config.get("main", "devices_file_dir")
-DEVICES_FILE_NAME = config.get("main", "devices_file_name")
-DEVICES_FILE_PATH = "{0}/{1}".format(DEVICES_FILE_DIR, DEVICES_FILE_NAME)
-SHUTDOWN_EMULATOR_ON_DISCONNECT = config.get("main", "shutdown_emulator_on_disconnect")
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -51,19 +45,22 @@ if __name__ == '__main__':
     signal.signal(signal.SIGINT, exit_gracefully)
     signal.signal(signal.SIGTERM, exit_gracefully)
     log.info("Starting connect service...")
-    with open(DEVICE_SPEC) as f:
+    with open(config.get("main", "device_spec")) as f:
         device_spec = json.load(f)
     if args['groups']:
         log.info('Working only with specified groups: {0}'.format(args['groups']))
         specified_groups = args["groups"].split(",")
         device_spec = [device_group for device_group in device_spec if device_group.get("group_name") in specified_groups]
     stf = SmartphoneTestingFarmClient(
-        host=HOST,
+        host=config.get("main", "host"),
         common_api_path="/api/v1",
-        oauth_token=OAUTH_TOKEN,
+        oauth_token=config.get("main", "oauth_token"),
         device_spec=device_spec,
-        devices_file_path=DEVICES_FILE_PATH,
-        shutdown_emulator_on_disconnect=SHUTDOWN_EMULATOR_ON_DISCONNECT
+        devices_file_path="{0}/{1}".format(
+            config.get("main", "devices_file_dir"),
+            config.get("main", "devices_file_name")
+        ),
+        shutdown_emulator_on_disconnect=config.get("main", "shutdown_emulator_on_disconnect")
     )
     devices_connector_thread = STFDevicesConnector(stf)
     devices_watcher_thread = STFConnectedDevicesWatcher(stf)

--- a/recorder.py
+++ b/recorder.py
@@ -16,13 +16,13 @@ def gracefully_exit(*args):
     exit(0)
 
 
-def wsfactory(address, directory, resolution, no_clean_old_data):
+def wsfactory(address, directory, resolution, keep_old_data):
     signal.signal(signal.SIGTERM, gracefully_exit)
     signal.signal(signal.SIGINT, gracefully_exit)
     log.info('Connecting to {0} ...'.format(address))
 
     directory = create_directory_if_not_exists(directory)
-    if not no_clean_old_data:
+    if not keep_old_data:
         remove_all_data(directory)
 
     factory = WebSocketClientFactory("ws://{0}".format(address))
@@ -111,7 +111,7 @@ if __name__ == '__main__':
         '-log-level', help='Log level'
     )
     parser.add_argument(
-        '-no-clean-old-data', help='Clean old data from directory', action='store_true'
+        '-no-clean-old-data', help='Do not clean old data from directory', action='store_true', default=False
     )
 
     args = vars(parser.parse_args())
@@ -124,5 +124,5 @@ if __name__ == '__main__':
         directory=args["dir"],
         resolution=args["resolution"],
         address=get_ws_url(args),
-        no_clean_old_data=args["no_clean_old_data"]
+        keep_old_data=args["no_clean_old_data"]
     )

--- a/recorder.py
+++ b/recorder.py
@@ -12,18 +12,18 @@ from stf_record.protocol import STFRecordProtocol
 
 
 logging.basicConfig(level=logging.INFO)
-log = logging.getLogger('stf-record')
+log = logging.getLogger("stf-record")
 
 
 def gracefully_exit(*args):
-    log.info('Disconnecting...')
+    log.info("Disconnecting...")
     exit(0)
 
 
 def wsfactory(address, directory, resolution, keep_old_data):
     signal.signal(signal.SIGTERM, gracefully_exit)
     signal.signal(signal.SIGINT, gracefully_exit)
-    log.info('Connecting to {0} ...'.format(address))
+    log.info("Connecting to {0} ...".format(address))
 
     directory = create_directory_if_not_exists(directory)
     if not keep_old_data:
@@ -37,7 +37,7 @@ def wsfactory(address, directory, resolution, keep_old_data):
 
     loop = asyncio.get_event_loop()
     coro = loop.create_connection(
-        factory, address.split(':')[0], address.split(':')[1]
+        factory, address.split(":")[0], address.split(":")[1]
     )
     loop.run_until_complete(coro)
     loop.run_forever()
@@ -45,24 +45,10 @@ def wsfactory(address, directory, resolution, keep_old_data):
 
 
 def create_directory_if_not_exists(directory):
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    if not directory:
-        directory = 'images'
-        log.debug(
-            'Directory not set. '
-            'Default directory is {0}'.format(directory)
-        )
-
+    directory = os.path.abspath(directory)
+    log.debug("Using directory \"{0}\" for storing images".format(directory))
     if not os.path.exists(directory):
-        os.mkdir(directory)
-
-    if directory[0] == ".":
-        directory = "{0}/{1}".format(current_dir, directory[2:])
-    elif directory[0] == "/":
-        directory = "{0}".format(directory)
-    else:
-        directory = "{0}/{1}".format(current_dir, directory)
-
+        os.makedirs(directory)
     return directory
 
 
@@ -78,7 +64,6 @@ def remove_all_data(directory):
 
 
 def get_ws_url(args):
-    # TODO: implement explicit but elegant generic_display_id processor
     if args["adb_connect_url"]:
         connected_devices_file_path = "{0}/{1}".format(
             config.get("main", "devices_file_dir"),
@@ -92,23 +77,23 @@ def get_ws_url(args):
         args["ws"] = props_json.get("device").get("display").get("url")
         log.debug("Got websocket url {0} by device serial {1} from stf API".format(args["ws"], args["serial"]))
 
-    address = args['ws'].split('ws://')[-1]
+    address = args["ws"].split("ws://")[-1]
     return address
 
 
 def _get_device_serial(adb_connect_url, connected_devices_file_path):
         device_serial = None
-        with open(connected_devices_file_path, 'r') as devices_file:
+        with open(connected_devices_file_path, "r") as devices_file:
             for line in devices_file.readlines():
                 line = json.loads(line)
-                log.debug(
-                    "Finding device serial of device connected as %s in %s" %
-                    (adb_connect_url, connected_devices_file_path)
-                )
+                log.debug("Finding device serial of device connected as {0} in {1}".format(
+                    adb_connect_url,
+                    connected_devices_file_path
+                ))
                 if line.get("adb_url") == adb_connect_url:
-                    log.debug(
-                        "Found device serial %s for device connected as %s" %
-                        (line.get("serial"), adb_connect_url)
+                    log.debug("Found device serial {0} for device connected as {1}".format(
+                        line.get("serial"),
+                        adb_connect_url)
                     )
                     device_serial = line.get("serial")
                     break
@@ -117,39 +102,39 @@ def _get_device_serial(adb_connect_url, connected_devices_file_path):
         return device_serial
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description='Utility for saving screenshots '
-                    'from devices with openstf minicap'
+        description="Utility for saving screenshots "
+                    "from devices with openstf minicap"
     )
     generic_display_id_group = parser.add_mutually_exclusive_group(required=True)
     generic_display_id_group.add_argument(
-        '-serial', help='Device serial'
+        "-serial", help="Device serial"
     )
     generic_display_id_group.add_argument(
-        '-ws', help='WebSocket URL'
+        "-ws", help="WebSocket URL"
     )
     generic_display_id_group.add_argument(
-        '-adb-connect-url', help='URL used to remote debug with adb connect, e.g. <host>:<port>'
+        "-adb-connect-url", help="URL used to remote debug with adb connect, e.g. <host>:<port>"
     )
     parser.add_argument(
-        '-dir', help='Directory for images'
+        "-dir", help="Directory for images", default="images"
     )
     parser.add_argument(
-        '-resolution', help='Resolution of images'
+        "-resolution", help="Resolution of images"
     )
     parser.add_argument(
-        '-log-level', help='Log level'
+        "-log-level", help="Log level"
     )
     parser.add_argument(
-        '-no-clean-old-data', help='Do not clean old data from directory', action='store_true', default=False
+        "-no-clean-old-data", help="Do not clean old data from directory", action="store_true", default=False
     )
 
     args = vars(parser.parse_args())
 
-    if args['log_level']:
-        log.info('Changed log level to {0}'.format(args['log_level'].upper()))
-        log.setLevel(args['log_level'].upper())
+    if args["log_level"]:
+        log.info("Changed log level to {0}".format(args["log_level"].upper()))
+        log.setLevel(args["log_level"].upper())
 
     wsfactory(
         directory=args["dir"],

--- a/stf_record/protocol.py
+++ b/stf_record/protocol.py
@@ -1,8 +1,5 @@
-import os
 import time
-import asyncio
 import logging
-from common.stfapi import api
 from autobahn.asyncio.websocket import WebSocketClientProtocol
 
 log = logging.getLogger('stf-record')

--- a/stf_record/protocol.py
+++ b/stf_record/protocol.py
@@ -44,7 +44,7 @@ class STFRecordProtocol(WebSocketClientProtocol):
         self._write_metadata(img_filename)
 
     def onOpen(self):
-        log.info('Starting recieve binary data')
+        log.info('Starting receive binary data')
         if self.resolution:
             self.sendMessage(self.resolution.encode('ascii'))
         self.sendMessage('on'.encode('ascii'))


### PR DESCRIPTION
Суть: 
Добавил (перенёс из тестов) в recorder.py логику по определению сериала девайса по его adb URL - то есть по строчке, которая отображается в `adb devices`, когда  подключаешь через stf-utils `<host>:<port>`

Проверял так - собрал докер образ локально с этой ветки `stf-utils`, в тестах локально убрал эту логику, запустил `ci.sh stages:ui_tests` - тесты отработали, видео записались.
