### PR TITLE
Add connect-and-quit mode to stf-connect

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
             'config/*.ini'
         ],
     },
-    version='0.0.3',
+    version='0.0.4',
     entry_points={
         'console_scripts': [
             'stf-connect = stf_utils.stf_connect.stf_connect:run',

--- a/stf_utils/stf_connect/client.py
+++ b/stf_utils/stf_connect/client.py
@@ -33,9 +33,6 @@ class Device:
 
 
 class SmartphoneTestingFarmClient(SmartphoneTestingFarmAPI):
-    device_connector = None
-    device_watcher = None
-
     def __init__(self, host, common_api_path, oauth_token, device_spec, shutdown_emulator_on_disconnect, devices_file_path):
         super(SmartphoneTestingFarmClient, self).__init__(host, common_api_path, oauth_token)
         self.device_groups = []
@@ -44,8 +41,6 @@ class SmartphoneTestingFarmClient(SmartphoneTestingFarmAPI):
         self.shutdown_emulator_on_disconnect = shutdown_emulator_on_disconnect
         self._set_up_device_groups()
         self.all_devices_are_connected = False
-        self.device_connector = STFDevicesConnector(self)
-        self.device_watcher = STFConnectedDevicesWatcher(self)
 
     def get_wanted_amount(self, group):
         amount = group.get("wanted_amount")
@@ -78,39 +73,6 @@ class SmartphoneTestingFarmClient(SmartphoneTestingFarmAPI):
                 appropriate_devices = self._filter_devices(self.available_devices, device_group)
                 devices_to_connect = appropriate_devices[:wanted_amount - actual_amount]
                 self._connect_added_devices(devices_to_connect, device_group)
-
-    def connect_and_quit(self, timeout):
-        start = time.time()
-        while time.time() < start + timeout:
-            if not self.all_devices_are_connected:
-                self.connect_devices()
-            else:
-                break
-            time.sleep(0.2)
-        else:
-            log.info("Timeout connecting devices {}".format(timeout))
-
-    def run_forever(self):
-        self._start_workers()
-        while True:
-            time.sleep(1)
-
-    def _start_workers(self):
-        self.device_watcher.start()
-        self.device_connector.start()
-
-    def _stop_workers(self):
-        if self.device_connector:
-            self.device_connector.stop()
-        if self.device_watcher:
-            self.device_watcher.stop()
-
-    def stop(self):
-        log.info("Stopping connect service...")
-        self._stop_workers()
-
-        log.debug("Stopping main thread...")
-        self.close_all()
 
     def get_amounts(self, device_group):
         wanted_amount = self.get_wanted_amount(device_group)

--- a/stf_utils/stf_connect/stf_connect.py
+++ b/stf_utils/stf_connect/stf_connect.py
@@ -40,7 +40,7 @@ class STFConnect:
         while True:
             time.sleep(1)
 
-    def connect_and_quit(self, timeout):
+    def connect_devices(self, timeout):
         start = time.time()
         while time.time() < start + timeout:
             if not self.client.all_devices_are_connected:
@@ -50,6 +50,7 @@ class STFConnect:
             time.sleep(0.2)
         else:
             log.info("Timeout connecting devices {}".format(timeout))
+            self.client.close_all()
 
     def _start_workers(self):
         self.watcher.start()
@@ -126,7 +127,7 @@ def run():
 
     log.info("Starting device connect service...")
     if args.connect_and_quit:
-        stf_connect.connect_and_quit(args.timeout)
+        stf_connect.connect_devices(args.timeout)
     else:
         stf_connect.run_forever()
 

--- a/stf_utils/stf_connect/stf_connect.py
+++ b/stf_utils/stf_connect/stf_connect.py
@@ -44,6 +44,15 @@ def parse_args():
     return parser.parse_args()
 
 
+def register_signal_handler(handler):
+    def exit_gracefully(signum, frame):
+        handler()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, exit_gracefully)
+    signal.signal(signal.SIGTERM, exit_gracefully)
+
+
 def run():
     args = parse_args()
     set_log_level(args.log_level)
@@ -65,13 +74,7 @@ def run():
         shutdown_emulator_on_disconnect=config.main.get("shutdown_emulator_on_disconnect")
     )
 
-    # Register exit handler
-    def exit_gracefully(signum, frame):
-        stf.stop()
-        sys.exit(0)
-
-    signal.signal(signal.SIGINT, exit_gracefully)
-    signal.signal(signal.SIGTERM, exit_gracefully)
+    register_signal_handler(stf.stop)
 
     log.info("Starting device connect service...")
     if args.connect_and_quit:

--- a/stf_utils/stf_connect/stf_connect.py
+++ b/stf_utils/stf_connect/stf_connect.py
@@ -6,7 +6,6 @@ import json
 import logging
 import signal
 import sys
-import time
 
 from stf_utils.config.config import initialize_config_file
 from stf_utils.stf_connect.client import SmartphoneTestingFarmClient, STFDevicesConnector, STFConnectedDevicesWatcher
@@ -36,34 +35,19 @@ def parse_args():
     parser.add_argument(
         "-c", "--config", help="Path to config file", default="stf-utils.ini"
     )
+    parser.add_argument(
+        "--connect-and-quit", help="Connect devices and exit", action='store_true', default=False
+    )
+    parser.add_argument(
+        "--timeout", help="Devices connect loop timeout", default=600
+    )
     return parser.parse_args()
 
 
 def run():
-    def exit_gracefully(signum, frame):
-        log.info("Stopping connect service...")
-        try:
-            thread_stop(devices_watcher_thread)
-            thread_stop(devices_connector_thread)
-        except NameError as e:
-            log.warning("Poll thread is not defined, skipping... {}".format(e))
-        log.debug("Stopping main thread...")
-        stf.close_all()
-        sys.exit(0)
-
-    def thread_stop(thread):
-        thread.stop()
-        thread.join()
-
     args = parse_args()
-    config = initialize_config_file(args.config)
-
-    signal.signal(signal.SIGINT, exit_gracefully)
-    signal.signal(signal.SIGTERM, exit_gracefully)
-
     set_log_level(args.log_level)
-    log.info("Starting connect service...")
-
+    config = initialize_config_file(args.config)
     with open(config.main.get("device_spec")) as f:
         device_spec = json.load(f)
 
@@ -80,13 +64,20 @@ def run():
         devices_file_path=config.main.get("devices_file_path"),
         shutdown_emulator_on_disconnect=config.main.get("shutdown_emulator_on_disconnect")
     )
-    devices_connector_thread = STFDevicesConnector(stf)
-    devices_watcher_thread = STFConnectedDevicesWatcher(stf)
-    devices_watcher_thread.start()
-    devices_connector_thread.start()
 
-    while True:
-        time.sleep(100)
+    # Register exit handler
+    def exit_gracefully(signum, frame):
+        stf.stop()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, exit_gracefully)
+    signal.signal(signal.SIGTERM, exit_gracefully)
+
+    log.info("Starting device connect service...")
+    if args.connect_and_quit:
+        stf.connect_and_quit(args.timeout)
+    else:
+        stf.run_forever()
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
+ `--connect-and-quit` param
+ `--timeout` param

+ everything about signals now inside `register_signal_handler` function
+ run_forever loop inside `STFConnect`
+ `device_connector` / `device_watcher` now part of `STFConnect`
+ `_start_workers` / `_stop_workers` methods

