### PR TITLE
Move call logging.basicConfig in only console run

### DIFF
--- a/stf_utils/__init__.py
+++ b/stf_utils/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+import logging
+
+
+def init_console_logging(level):
+    logging.basicConfig(level=getattr(logging, level.upper()))

--- a/stf_utils/stf_connect/stf_connect.py
+++ b/stf_utils/stf_connect/stf_connect.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import os
 import argparse
 import json
 import logging
@@ -8,18 +7,11 @@ import signal
 import sys
 import time
 
+from stf_utils import init_console_logging
 from stf_utils.config.config import initialize_config_file
 from stf_utils.stf_connect.client import SmartphoneTestingFarmClient, STFDevicesConnector, STFConnectedDevicesWatcher
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
-logging.basicConfig(level=getattr(logging, LOG_LEVEL))
 log = logging.getLogger(__name__)
-
-
-def set_log_level(_log_level):
-    if _log_level:
-        log.debug("Changed log level to {0}".format(_log_level.upper()))
-        log.setLevel(_log_level.upper())
 
 
 class STFConnect:
@@ -92,7 +84,7 @@ def parse_args():
         "-g", "--groups", help="Device groups defined in spec file to connect"
     )
     parser.add_argument(
-        "-l", "--log-level", help="Log level"
+        "-l", "--log-level", help="Log level (default: INFO)", default="INFO"
     )
     parser.add_argument(
         "-c", "--config", help="Path to config file", default="stf-utils.ini"
@@ -118,7 +110,7 @@ def register_signal_handler(handler):
 
 def run():
     args = parse_args()
-    set_log_level(args.log_level)
+    init_console_logging(args.log_level)
     config = initialize_config_file(args.config)
 
     device_spec = get_spec(config.main.get("device_spec"), args.groups)

--- a/stf_utils/stf_record/stf_record.py
+++ b/stf_utils/stf_record/stf_record.py
@@ -1,4 +1,5 @@
-import os
+# -*- coding: utf-8 -*-
+
 import argparse
 import asyncio
 import json
@@ -9,12 +10,12 @@ from autobahn.asyncio.websocket import WebSocketClientFactory
 
 import functools
 import os
+
+from stf_utils import init_console_logging
 from stf_utils.common.stfapi import SmartphoneTestingFarmAPI
 from stf_utils.config.config import initialize_config_file
 from stf_utils.stf_record.protocol import STFRecordProtocol
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
-logging.basicConfig(level=getattr(logging, LOG_LEVEL))
 log = logging.getLogger(__name__)
 
 
@@ -126,7 +127,7 @@ def run():
         "-r", "--resolution", help="Resolution of images"
     )
     parser.add_argument(
-        "-l", "--log-level", help="Log level"
+        "-l", "--log-level", help="Log level (default: INFO)", default="INFO"
     )
     parser.add_argument(
         "-k", "--keep-old-data", help="Do not clean old data from directory", action="store_true", default=False
@@ -136,12 +137,9 @@ def run():
     )
 
     args = vars(parser.parse_args())
+    init_console_logging(args["log_level"])
     config_file = args["config"]
     config = initialize_config_file(config_file)
-
-    if args["log_level"]:
-        log.debug("Changed log level to {0}".format(args["log_level"].upper()))
-        log.setLevel(args["log_level"].upper())
 
     api = SmartphoneTestingFarmAPI(
         host=config.main.get("host"),


### PR DESCRIPTION
Теперь не будет настраиваться логирование при импорте частей stf-utils как питон пакетов